### PR TITLE
fix/network_socket_timeout

### DIFF
--- a/clamav_client/clamd.py
+++ b/clamav_client/clamd.py
@@ -67,8 +67,8 @@ class ClamdNetworkSocket:
         """
         try:
             self.clamd_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.clamd_socket.connect((self.host, self.port))
             self.clamd_socket.settimeout(self.timeout)
+            self.clamd_socket.connect((self.host, self.port))
         except OSError as err:
             raise CommunicationError(self._error_message(err)) from err
 


### PR DESCRIPTION
Hi @sevein 

I noticed that the `timeout` parameter passed to a `ClamdScanner` is ignored when:
- the provided address is wrong (typo in URL)
- the server is not reachable
- ...

Setting the timeout, then trying to connect fixes this issue. 

Not sure how you'd like PRs to be done, so let me know if I need to do anything else.