### PR TITLE
Download main and daily dbs in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
           unix_socket: ${{ env.CLAMD_UNIX_SOCKET }}
           tcp_port: ${{ env.CLAMD_TCP_PORT }}
           stream_max_length: 1M
+          db_main: true
+          db_daily: true
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,12 +19,6 @@ from clamav_client.scanner import get_scanner
 
 CI = True if "CI" in environ or "GITHUB_REF" in environ else False
 
-# TODO: figure out this discrepancy - likely because we're missing recent sigs
-# in the CI job.
-EICAR_NAME = "Win.Test.EICAR_HDB-1"
-if CI:
-    EICAR_NAME = "Eicar-Test-Signature"
-
 
 @pytest.fixture
 def ci() -> bool:
@@ -33,7 +27,7 @@ def ci() -> bool:
 
 @pytest.fixture
 def eicar_name() -> str:
-    return EICAR_NAME
+    return "Win.Test.EICAR_HDB-1"
 
 
 @pytest.fixture


### PR DESCRIPTION
In CI, the EICAR test file keeps getting flagged either as "Eicar-Test-Signature" or "Eicar-Signature", which causes inconsistent build failures. I'm not sure why this happens, so I'll try this solution for now. It will slow down the builds a bit, but that’s acceptable.

Looks like `"Win.Test.EICAR_HDB-1"` is returned consistently with the main and daily dbs downloaded.