### PR TITLE
use sendall vs send which does not guarentee all bytes will be sent

### DIFF
--- a/clamav_client/clamd.py
+++ b/clamav_client/clamd.py
@@ -178,9 +178,9 @@ class ClamdNetworkSocket:
             chunk = buff.read(max_chunk_size)
             while chunk:
                 size = struct.pack(b"!L", len(chunk))
-                self.clamd_socket.send(size + chunk)
+                self.clamd_socket.sendall(size + chunk)
                 chunk = buff.read(max_chunk_size)
-            self.clamd_socket.send(struct.pack(b"!L", 0))
+            self.clamd_socket.sendall(struct.pack(b"!L", 0))
             result = self._recv_response()
             if len(result) > 0:
                 if result == "INSTREAM size limit exceeded. ERROR":
@@ -217,7 +217,7 @@ class ClamdNetworkSocket:
         if args:
             concat_args = " " + " ".join(args)
         send = f"n{cmd}{concat_args}\n".encode()
-        self.clamd_socket.send(send)
+        self.clamd_socket.sendall(send)
 
     def _recv_response(self) -> str:
         """


### PR DESCRIPTION
In clamav_client.clamd there are three uses of self.clamd_socket.send. Socket.send is a low-level function which does not (necessarily, by contract) send the entire buffer. Instead it returns the number of bytes actually sent, and the caller is required to manage the unsent bytes by passing them to socket.send until all are sent.

from the python spec for send: https://docs.python.org/3/library/socket.html#socket.socket.send

_Send data to the socket. The socket must be connected to a remote socket. The optional flags argument has the same meaning as for [recv()](https://docs.python.org/3/library/socket.html#socket.socket.recv) above. **Returns the number of bytes sent. Applications are responsible for checking that all data has been sent**; if only some of the data was transmitted, the application needs to attempt delivery of the remaining data._

compare to sendall: https://docs.python.org/3/library/socket.html#socket.socket.sendall

_**Unlike [send()](https://docs.python.org/3/library/socket.html#socket.socket.send), this method continues to send data from bytes until either all data has been sent or an error occurs**._

In the existing code, the return value from socket.send is not checked. This is something the library generally "gets away with" since it is sending at most 1024 bytes per send. However under gevent this is causing failures since the threads are changed more frequently. So we're seeing the impact of this defect (as was the author of this PR in 2021 against the source repo of clamd: https://github.com/graingert/python-clamd/pull/23).

The PR presented replaces the low-level "send" call with the required "sendall" call which behaves as the code appears to expect.